### PR TITLE
Update skill books; Add support for dark scheme

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -161,3 +161,32 @@ input[type=checkbox]:checked + label:after {
     min-width: 0;
   }
 }
+
+@media screen and (prefers-color-scheme: dark) {
+    /* Overrides for when the user has requested a dark color scheme */
+    /* through an operating system or a user agent setting. */
+    body {
+      color: #d6d0c6;
+      background: #1f2020;
+    }
+    .checklist {
+      background: #2d2d2d;
+      box-shadow: 0 4px 8px #090909;
+    }
+    tr:hover {
+      background-color: #404040;
+    }
+    .notes textarea {
+        background: #5d5d5d;
+        border: 1px solid #5a5a5a;
+      }
+    .notes textarea:focus {
+      box-shadow: 0 0 8px rgba(9, 9, 9, 0.5);
+    }
+    input[type=checkbox] + label:after {
+      color: #cccccc;
+    }
+    input[type=checkbox] + label:hover {
+      box-shadow: 0 2px 3px rgba(9, 9, 9, 0.5) inset;
+    }
+  }

--- a/js/app/data.js
+++ b/js/app/data.js
@@ -4,7 +4,7 @@ define('Data', function() {
 	var Data = {};
 	var storage = localStorage || {};
 	var houses = ['house 1', 'house 2', 'house 3', 'house 4', 'house 5', 'house 6'];
-	var levels = ['beginner', 'intermediate', 'advanced', 'expert', 'master'];
+	var levels = ['Vol. 1', 'Vol. 2', 'Vol. 3', 'Vol. 4', 'Vol. 5'];
 	var tableTemplate = 'table-checklist';
 	var listTemplate = 'list-checklist';
 	var defaults = {
@@ -12,10 +12,14 @@ define('Data', function() {
 			{label: 'skillbooks', templateType: tableTemplate, headers: levels, checklistItems: [
 				{label: 'carpentry', checkableItems: levels, checkedItems: []},
 				{label: 'cooking', checkableItems: levels, checkedItems: []},
+				{label: 'electrician', checkableItems: levels, checkedItems: []},
 				{label: 'farming', checkableItems: levels, checkedItems: []},
 				{label: 'first aid', checkableItems: levels, checkedItems: []},
 				{label: 'fishing', checkableItems: levels, checkedItems: []},
+				{label: 'foraging', checkableItems: levels, checkedItems: []},
+				{label: 'mechanics', checkableItems: levels, checkedItems: []},
 				{label: 'metalwork', checkableItems: levels, checkedItems: []},
+				{label: 'tailoring', checkableItems: levels, checkedItems: []},
 				{label: 'trapping', checkableItems: levels, checkedItems: []}
 			]},
 			{label: 'tool bag', templateType: tableTemplate, headers: houses, checklistItems: [
@@ -63,7 +67,7 @@ define('Data', function() {
 				{label: 'lighters', checkableItems: houses, checkedItems: []},
 				{label: 'matches', checkableItems: houses, checkedItems: []},
 				{label: 'campfire kits', checkableItems: houses, checkedItems: []},
-				{label: 'tent kits', checkableItems: houses, checkedItems: []}						
+				{label: 'tent kits', checkableItems: houses, checkedItems: []}
 			]},
 			{label: 'Cooking Utensils', templateType: tableTemplate, headers: houses, checklistItems: [
 				{label: 'spoons', checkableItems: houses, checkedItems: []},


### PR DESCRIPTION
Updated skill books to match the current game state (as of 41.72 but probably earlier). List can be verified via the WIKI: https://pzwiki.net/wiki/Skill_Books

Added basic support for dark scheme. Configured on the OS or browser level. Preview:
<img src="https://user-images.githubusercontent.com/762122/178149644-40e27c42-fa60-427e-ac93-9b37ea9c5f9c.png" width=50% height=50%>